### PR TITLE
Add support for specifying the app_id

### DIFF
--- a/lennoxs30api/__init__.py
+++ b/lennoxs30api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 from .lennox_home import *
 from .lennox_period import *
 from .lennox_schedule import *

--- a/lennoxs30api/s30api_async.py
+++ b/lennoxs30api/s30api_async.py
@@ -116,19 +116,27 @@ class s30api_async(object):
 
     """Representation of the Lennox S30/E30 thermostat."""
 
-    def __init__(self, username: str, password: str):
+    def __init__(self, username: str, password: str, app_id: str):
         """Initialize the API interface."""
         self._username = username
         self._password = password
         # Generate a unique app id, following the existing formatting
-        dt = datetime.now()
-        epoch_time = dt.strftime("%Y%m%d%H%M%S")
-        appPrefix = APPLICATION_ID[: len(APPLICATION_ID) - len(epoch_time)]
-        app_id = appPrefix + epoch_time
-
-        self._applicationid: str = app_id
-
-        _LOGGER.info("__init__ S30TStat  applicationId [" + self._applicationid + "]")
+        if app_id is None:
+            dt = datetime.now()
+            epoch_time = dt.strftime("%Y%m%d%H%M%S")
+            appPrefix = APPLICATION_ID[: len(APPLICATION_ID) - len(epoch_time)]
+            app_id = appPrefix + epoch_time
+            self._applicationid: str = app_id
+            _LOGGER.info(
+                "__init__  generating unique applicationId ["
+                + self._applicationid
+                + "]"
+            )
+        else:
+            self._applicationid: str = app_id
+            _LOGGER.info(
+                "__init__ using provided applicationId [" + self._applicationid + "]"
+            )
 
         self._publishMessageId: int = 1
         self._session: ClientSession = None

--- a/lennoxs30api/s30exception.py
+++ b/lennoxs30api/s30exception.py
@@ -12,13 +12,16 @@ EC_COMMS_ERROR = 11
 EC_NO_SCHEDULE = 12
 EC_HTTP_ERR = 13
 EC_LOGOUT = 14
+EC_CONFIG_TIMEOUT = 15
 EC_UNAUTHORIZED = 401
 
+
 class S30Exception(Exception):
-   def __init__(self, value: str, error_code: int, reference: int) -> None:
+    def __init__(self, value: str, error_code: int, reference: int) -> None:
         """Initialize error."""
         super().__init__(self, value)
         self.message = value
         self.error_code = error_code
         self.reference = reference
-   pass
+
+    pass

--- a/samples/test_async.py
+++ b/samples/test_async.py
@@ -9,16 +9,18 @@ import sys
 import asyncio
 
 ###### ENIVRONMENT SETUP #####################
-LOG_PATH = '/home/pete'    #  Directoy to stash the log file in
-EMAIL_ADDRESS = 'myemail@myemail.com'
-PASSWORD = 'mypassword'
+LOG_PATH = "/home/pete"  #  Directoy to stash the log file in
+EMAIL_ADDRESS = "myemail@myemail.com"
+PASSWORD = "mypassword"
 
 
-logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
+logFormatter = logging.Formatter(
+    "%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s"
+)
 rootLogger = logging.getLogger()
 rootLogger.setLevel(level=logging.DEBUG)
 
-fileHandler = logging.FileHandler("{0}/{1}.log".format(LOG_PATH, 'log.txt'))
+fileHandler = logging.FileHandler("{0}/{1}.log".format(LOG_PATH, "log.txt"))
 fileHandler.setFormatter(logFormatter)
 fileHandler.setLevel(logging.DEBUG)
 rootLogger.addHandler(fileHandler)
@@ -28,7 +30,7 @@ consoleHandler.setLevel(logging.DEBUG)
 rootLogger.addHandler(consoleHandler)
 
 # This task gets messages from Cloud and processes them
-async def cloud_message_pump_task(s30api:s30api_async) -> None:
+async def cloud_message_pump_task(s30api: s30api_async) -> None:
     try:
         # Login and establish connection
         await s30api.serverConnect()
@@ -39,7 +41,7 @@ async def cloud_message_pump_task(s30api:s30api_async) -> None:
     except S30Exception as e:
         print("Failed to connect error " + str(e))
         return
-    while (True):
+    while True:
         # Checks for new messages and processes them which may update the state of zones, etc.
         try:
             print("Message Pump Awake")
@@ -49,11 +51,12 @@ async def cloud_message_pump_task(s30api:s30api_async) -> None:
         except S30Exception as e:
             print("Message pump error " + str(e))
 
+
 # This task periodically polls the API for data and prints it.  These calls are just accessing local state, that
 # may get updated by the message pump task.  You could also set up a callback on a Zone or System and get notified when the
 # entity changes - perhaps in another example!
-async def api_poller_task(s30api):        
-    while (True):
+async def api_poller_task(s30api):
+    while True:
         print("Poller Awake")
         try:
             for lsystem in s30api.getSystems():
@@ -69,9 +72,11 @@ async def api_poller_task(s30api):
         await asyncio.sleep(15)
 
 
-# I found this example of how to read from the command prompt async. 
+# I found this example of how to read from the command prompt async.
 # https://stackoverflow.com/questions/35223896/listen-to-keypress-with-asyncio
 import functools
+
+
 class Prompt:
     def __init__(self, loop=None):
         self.loop = loop or asyncio.get_event_loop()
@@ -81,60 +86,67 @@ class Prompt:
     def got_input(self):
         asyncio.ensure_future(self.q.put(sys.stdin.readline()), loop=self.loop)
 
-    async def __call__(self, msg, end='\n', flush=False):
+    async def __call__(self, msg, end="\n", flush=False):
         print(msg, end=end, flush=flush)
-        return (await self.q.get()).rstrip('\n')
+        return (await self.q.get()).rstrip("\n")
+
 
 prompt = Prompt()
-raw_input = functools.partial(prompt, end='', flush=True)
+raw_input = functools.partial(prompt, end="", flush=True)
 
 # This task gets input from the command prompt and executes task.
 async def command_reader_task(s30api):
-    while (True):
+    while True:
         try:
-            input = await raw_input('enter cmd:')
-            splits = input.split(' ')
+            input = await raw_input("enter cmd:")
+            splits = input.split(" ")
             res = splits[0]
-            print('Result [' + res + ']')
+            print("Result [" + res + "]")
             # By default we'll use Zone_1 on the first S30 found
-            zone:lennox_zone = None
+            zone: lennox_zone = None
             if s30api.getSystems() != None and len(s30api.getSystems()) > 0:
-                system:lennox_system = s30api.getSystems()[0]
+                system: lennox_system = s30api.getSystems()[0]
                 zone = system.getZone(0)
                 # Zone configuration usually arrives within 5-10 seconds.  In a real program you may wait for it to come in
                 # before really starting up.
                 print("zone configuration not received, command ignored")
                 continue
-            if (res == 'cool' or res == 'off' or res or 'heat'):
-                print("Set HVAC Mode [" + res + ']')
+            if res == "cool" or res == "off" or res or "heat":
+                print("Set HVAC Mode [" + res + "]")
                 cmdres = await zone.setHVACMode(res)
-                print("Command Result [" + str(cmdres) + ']')
-            if (res == 'circulate' or res == 'auto' or res == 'on'):
-                print("Set Fan Mode [" + res + ']')
+                print("Command Result [" + str(cmdres) + "]")
+            if res == "circulate" or res == "auto" or res == "on":
+                print("Set Fan Mode [" + res + "]")
                 cmdres = await zone.setFanMode(res)
-                print("Command Result [" + str(cmdres) + ']')
-            if (res == 'csp'):
+                print("Command Result [" + str(cmdres) + "]")
+            if res == "csp":
                 par = splits[1]
-                print("Cool Setpoint [" + par + ']')
+                print("Cool Setpoint [" + par + "]")
                 cmdres = await zone.setCoolSPF(par)
-                print("Command Result [" + str(cmdres) + ']')
-            if (res == 'hsp'):
+                print("Command Result [" + str(cmdres) + "]")
+            if res == "hsp":
                 par = splits[1]
-                print("Heat Setpoint [" + par + ']')
+                print("Heat Setpoint [" + par + "]")
                 cmdres = await zone.setHeatSPF(par)
-                print("Command Result [" + str(cmdres) + ']')
+                print("Command Result [" + str(cmdres) + "]")
         except Exception as e:
             print("Exception " + str(e))
 
+
 async def multiple_tasks(s30api):
-  input_coroutines = [cloud_message_pump_task(s30api), api_poller_task(s30api), command_reader_task(s30api)]
-  res = await asyncio.gather(*input_coroutines, return_exceptions=True)
-  return res        
+    input_coroutines = [
+        cloud_message_pump_task(s30api),
+        api_poller_task(s30api),
+        command_reader_task(s30api),
+    ]
+    res = await asyncio.gather(*input_coroutines, return_exceptions=True)
+    return res
+
 
 def main():
-    s30api = s30api_async(EMAIL_ADDRESS, PASSWORD)
+    s30api = s30api_async(EMAIL_ADDRESS, PASSWORD, None)
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(multiple_tasks(s30api))    
+    loop.run_until_complete(multiple_tasks(s30api))
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="lennoxs30api",
-    version="0.0.8",
+    version="0.0.9",
     description="API Wrapper for Lennox S30 Cloud API",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/PeteRager/lennoxs30api",
-    author="Pete Sage",
+    author="Pete Rage",
     author_email="pete.saged@icloud.com",
     license="MIT",
     classifiers=[

--- a/tests/test_config_response.py
+++ b/tests/test_config_response.py
@@ -11,7 +11,7 @@ def setup_load_configuration() -> s30api_async:
     with open(file_path) as f:
         data = json.load(f)
 
-    api = s30api_async("myemail@email.com", "mypassword")
+    api = s30api_async("myemail@email.com", "mypassword", None)
     api.process_login_response(data)
 
     file_path = os.path.join(script_dir, "config_response_system_01.json")

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -11,7 +11,7 @@ def setup_load_configuration() -> s30api_async:
     with open(file_path) as f:
         data = json.load(f)
 
-    api = s30api_async("myemail@email.com", "mypassword")
+    api = s30api_async("myemail@email.com", "mypassword", None)
     api.process_login_response(data)
 
     file_path = os.path.join(script_dir, "config_response_system_01.json")

--- a/tests/test_login_response.py
+++ b/tests/test_login_response.py
@@ -11,7 +11,7 @@ def test_process_login_message():
     with open(file_path) as f:
         data = json.load(f)
 
-    api = s30api_async("myemail@email.com", "mypassword")
+    api = s30api_async("myemail@email.com", "mypassword", None)
 
     api.process_login_response(data)
 

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -31,7 +31,7 @@ def loadfile(name) -> json:
 
 
 def setup_load_configuration() -> s30api_async:
-    api = s30api_async("myemail@email.com", "mypassword")
+    api = s30api_async("myemail@email.com", "mypassword", None)
 
     data = loadfile("login_response.json")
     api.process_login_response(data)
@@ -192,7 +192,7 @@ def test_hvac_mode_change_zone_2():
 # Sometimes an config update message arrives before the full config, this
 # test case checks this behavior, it does not happen often.
 def test_data_before_config() -> s30api_async:
-    api = s30api_async("myemail@email.com", "mypassword")
+    api = s30api_async("myemail@email.com", "mypassword", None)
 
     data = loadfile("login_response.json")
     api.process_login_response(data)

--- a/tests/test_setpoints.py
+++ b/tests/test_setpoints.py
@@ -15,7 +15,7 @@ def setup_load_configuration() -> s30api_async:
     with open(file_path) as f:
         data = json.load(f)
 
-    api = s30api_async("myemail@email.com", "mypassword")
+    api = s30api_async("myemail@email.com", "mypassword", None)
     api.process_login_response(data)
 
     file_path = os.path.join(script_dir, "config_response_system_01.json")


### PR DESCRIPTION
Sometimes messages will not be delivered when we create a unique application id.  The reasons for this in unclear.  However, by allowing the app_id to be specified with a value that does work, this works around the issue.