### PR TITLE
Log sibling messages

### DIFF
--- a/lennoxs30api/s30api_async.py
+++ b/lennoxs30api/s30api_async.py
@@ -753,6 +753,7 @@ class s30api_async(object):
                     _LOGGER.error(
                         f"processMessage dropping message from unknown SenderId/SystemId [{sysId}] - please consult https://github.com/PeteRager/lennoxs30/blob/master/docs/sibling.md for configuration assistance"
                     )
+                    _LOGGER.error(json.dumps(message, indent=4))                    
                     self._badSenderDict[sysId] = sysId
             else:
                 self.metrics.inc_sibling_message_drop()
@@ -760,6 +761,7 @@ class s30api_async(object):
                     _LOGGER.warning(
                         f"processMessage dropping message from sibling [{sysId}] for system [{system.sysId}] - please consult https://github.com/PeteRager/lennoxs30/blob/master/docs/sibling.md for configuration assistance"
                     )
+                    _LOGGER.warning(json.dumps(message, indent=4))                    
                 else:
                     _LOGGER.debug(f"processMessage dropping message from sibling [{sysId}] for system [{system.sysId}]")
 

--- a/tests/test_api_process_message.py
+++ b/tests/test_api_process_message.py
@@ -27,16 +27,17 @@ def test_api_process_sibling_message(api: s30api_async, caplog):
     api.metrics.reset()
     with caplog.at_level(logging.DEBUG):
         api.processMessage(message)
-        assert len(caplog.records) == 1
+        assert len(caplog.records) == 2
         assert "KL21J00002" in caplog.messages[0]
         assert caplog.records[0].levelname == "WARNING"
         assert api.metrics.sibling_message_drop == 1
         assert api.metrics.sender_message_drop == 0
+        assert "KL21J00002" in caplog.messages[1]
 
         api.processMessage(message)
-        assert len(caplog.records) == 2
-        assert "KL21J00002" in caplog.messages[1]
-        assert caplog.records[1].levelname == "DEBUG"
+        assert len(caplog.records) == 3
+        assert "KL21J00002" in caplog.messages[2]
+        assert caplog.records[2].levelname == "DEBUG"
         assert api.metrics.sibling_message_drop == 2
         assert api.metrics.sender_message_drop == 0
 
@@ -52,13 +53,16 @@ def test_api_process_unknown_sender(api: s30api_async, caplog):
     with caplog.at_level(logging.DEBUG):
         # First message should result in an Error Logged and an entry for the bad second in the dict
         api.processMessage(message)
-        assert len(caplog.records) == 1
+        assert len(caplog.records) == 2
         assert "KL21J00002" in caplog.messages[0]
         assert caplog.records[0].levelname == "ERROR"
         assert api.metrics.sibling_message_drop == 0
         assert api.metrics.sender_message_drop == 1
         assert len(api._badSenderDict) == 1
         assert "KL21J00002" in api._badSenderDict
+        # The message should be dumped into the log
+        assert "KL21J00002" in caplog.messages[1]
+
         # Second message should result in an Debug message logged
         caplog.clear()
         api.processMessage(message)
@@ -73,7 +77,7 @@ def test_api_process_unknown_sender(api: s30api_async, caplog):
         message["SenderId"] = "KL21J00003"
         caplog.clear()
         api.processMessage(message)
-        assert len(caplog.records) == 1
+        assert len(caplog.records) == 2
         assert "KL21J00003" in caplog.messages[0]
         assert caplog.records[0].levelname == "ERROR"
         assert api.metrics.sibling_message_drop == 0


### PR DESCRIPTION
When encountering the first message from a sibling or from an unknown sender, dump the message to the error log.